### PR TITLE
getCurvePoints() - returns empty array when points are empty

### DIFF
--- a/src/curve_calc.js
+++ b/src/curve_calc.js
@@ -20,6 +20,11 @@ function getCurvePoints(points, tension, numOfSeg, close) {
 
 	'use strict';
 
+	// just return an empty list of no points are passed
+	if (!points || points.length === 0) {
+		return [];
+	}
+
 	// options or defaults
 	tension = (typeof tension === 'number') ? tension : 0.5;
 	numOfSeg = (typeof numOfSeg === 'number') ? numOfSeg : 25;


### PR DESCRIPTION
Hey! Thanks for a useful module. 👍

I'm using `getCurvePoints(...)` to get a smoothened list of points for an SVG graphs. At times, my list of points are empty, and passing this empty list to `getCurvePoints(...)` throws an error.

To me, it makes more sense to return empty results for empty inputs. However, I don't know the rest of this package well, so just close this PR if it doesn't make sense elsewhere.


Cheers